### PR TITLE
Fix typo in bolukbasi definitional pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -274,7 +274,7 @@ If you'd like to add new seed sets or improve the documentation for this project
 **Used in Paper:** Man is to Computer Programmer as Woman is to Homemaker? Debiasing Word Embeddings (Bolukbasi et al., 2016)  
 **Source Categories:** curated  
 **Link:** [https://github.com/tolga-b/debiaswe](https://github.com/tolga-b/debiaswe)  
-**Seeds:** [woman, girl, she, mother, daugher, gal, female, her, herself, Mary]
+**Seeds:** [woman, girl, she, mother, daughter, gal, female, her, herself, Mary]
 
 **Seeds ID:** definitional_male-Bolukbasi_et_al_2016  
 **Category:** definitional male   

--- a/gathered_seeds.json
+++ b/gathered_seeds.json
@@ -307,7 +307,7 @@
   },
   {
     "Category":"definitional female",
-    "Seeds":"['woman', 'girl', 'she', 'mother', 'daugher', 'gal', 'female', 'her', 'herself', 'Mary']",
+    "Seeds":"['woman', 'girl', 'she', 'mother', 'daughter', 'gal', 'female', 'her', 'herself', 'Mary']",
     "Source \/ Justification":null,
     "Source Categories":"curated",
     "Used in Paper":"Man is to Computer Programmer as Woman is to Homemaker? Debiasing Word Embeddings (Bolukbasi et al., 2016)",


### PR DESCRIPTION
Hi! Thank you for this very valuable resource!

Just a quick note, from what I can tell there is a typo in the definitional-pairs gathered from Bolukbasi et al.
In particular, "daugher" should be "daughter", as can be seen in the [equivalent file in the Bolukbasi repository](https://github.com/tolga-b/debiaswe/blob/master/data/definitional_pairs.json).
This pull request fixes this typo in both the README.md and gathered-seeds.json files.

PS: fwiw, I noticed a similar typo in the bolukbasi gender specific seed set, but have left it untouched since the same typo is [present in the original repo](https://github.com/tolga-b/debiaswe/search?q=daugher).

Thanks, please let me know if you disagree with this pull request. 